### PR TITLE
Add thraml.com

### DIFF
--- a/index.json
+++ b/index.json
@@ -1052,6 +1052,7 @@
   "thecloudindex.com",
   "thepryam.info",
   "thisisnotmyrealemail.com",
+  "thraml.com",
   "thrma.com",
   "throam.com",
   "thrott.com",


### PR DESCRIPTION
the new email-handling domain of throwawaymail.com
